### PR TITLE
use gmdate() to return UTC time that is expected

### DIFF
--- a/lib/serverdensity/Api/Metrics.php
+++ b/lib/serverdensity/Api/Metrics.php
@@ -16,8 +16,8 @@ class Metrics extends AbstractApi
     */
     public function available($id, $start, $end){
         $param = array(
-            'start' => date("Y-m-d\TH:i:s\Z", $start),
-            'end' => date("Y-m-d\TH:i:s\Z", $end)
+            'start' => gmdate("Y-m-d\TH:i:s\Z", $start),
+            'end' => gmdate("Y-m-d\TH:i:s\Z", $end)
         );
 
         return $this->get('metrics/definitions/'.urlencode($id), $param);
@@ -35,8 +35,8 @@ class Metrics extends AbstractApi
     */
     public function metrics($id, $filter, $start, $end){
         $param = array(
-            'start' => date("Y-m-d\TH:i:s\Z", $start),
-            'end' => date("Y-m-d\TH:i:s\Z", $end),
+            'start' => gmdate("Y-m-d\TH:i:s\Z", $start),
+            'end' => gmdate("Y-m-d\TH:i:s\Z", $end),
             'filter' => $filter
         );
 


### PR DESCRIPTION
On https://apidocs.serverdensity.com/?php#available-metrics the start and end dates are expected to be in UTC, however using date() causes the passed timestamp to be formatted in the server's local time rather than UTC (which is what the API expects).

See: http://php.net/manual/en/function.gmdate.php

Cheers!
