### PR TITLE
Dynamic Metrics

### DIFF
--- a/lib/serverdensity/Api/Metrics.php
+++ b/lib/serverdensity/Api/Metrics.php
@@ -48,23 +48,19 @@ class Metrics extends AbstractApi
     /**
     * Get dynamic metrics
     * @link     https://apidocs.serverdensity.com/?python#get-metrics
-    * @param 	string		$inventoryFilter the filter to use to find inventory
     * @param    array       $filter an array of what you want to filter
     * @param    timestamp   $start  the start of the period.
     * @param    timestamp   $end    the end of the period
+    * @param    string      $inventoryFilter the filter to use to find inventory
+    * @param    array       $ids an array of ids that you want to filter for.
+    * @param    array       $names an array of names that you would like to filter for.
     * @return   an array that is all available metrics.
     */
-    public function dynamicMetrics($filter, $start, $end, $inventoryFilter=Null, $ids=Null, $names=Null){
+    public function dynamicMetrics($filter, $start, $end, $inventoryFilter=Null){
         $urlencoded = '';
         $query = array();
         if (isset($inventoryFilter)){
             $query['inventoryFilter'] = $inventoryFilter;
-        }
-        if (isset($ids)){
-            $query['ids'] = $ids;
-        }
-        if (isset($names)){
-            $query['names'] = $names;
         }
         if (!empty($query)){
             $urlencoded = '?' . http_build_query($query);

--- a/lib/serverdensity/Api/Metrics.php
+++ b/lib/serverdensity/Api/Metrics.php
@@ -48,7 +48,7 @@ class Metrics extends AbstractApi
     /**
     * Get dynamic metrics
     * @link     https://apidocs.serverdensity.com/?python#get-metrics
-    * @param 	string		$inventoryFilter the filter to use to find inventory    
+    * @param 	string		$inventoryFilter the filter to use to find inventory
     * @param    array       $filter an array of what you want to filter
     * @param    timestamp   $start  the start of the period.
     * @param    timestamp   $end    the end of the period
@@ -56,8 +56,8 @@ class Metrics extends AbstractApi
     */
     public function dynamicMetrics($inventoryFilter, $filter, $start, $end){
         $param = array(
-            'start' => gmdate("Y-m-d\TH:i:s\Z", $start),
-            'end' => gmdate("Y-m-d\TH:i:s\Z", $end),
+            'start' => date("Y-m-d\TH:i:s\Z", $start),
+            'end' => date("Y-m-d\TH:i:s\Z", $end),
             'filter' => $filter
         );
 

--- a/lib/serverdensity/Api/Metrics.php
+++ b/lib/serverdensity/Api/Metrics.php
@@ -54,7 +54,22 @@ class Metrics extends AbstractApi
     * @param    timestamp   $end    the end of the period
     * @return   an array that is all available metrics.
     */
-    public function dynamicMetrics($inventoryFilter, $filter, $start, $end){
+    public function dynamicMetrics($filter, $start, $end, $inventoryFilter=Null, $ids=Null, $names=Null){
+        $urlencoded = '';
+        $query = array();
+        if (isset($inventoryFilter)){
+            $query['inventoryFilter'] = $inventoryFilter;
+        }
+        if (isset($ids)){
+            $query['ids'] = $ids;
+        }
+        if (isset($names)){
+            $query['names'] = $names;
+        }
+        if (!empty($query)){
+            $urlencoded = '?' . http_build_query($query);
+        }
+
         $param = array(
             'start' => date("Y-m-d\TH:i:s\Z", $start),
             'end' => date("Y-m-d\TH:i:s\Z", $end),
@@ -63,7 +78,7 @@ class Metrics extends AbstractApi
 
         $param = $this->makeJsonReady($param);
 
-        return $this->get('metrics/dynamicgraphs/?inventoryFilter='.urlencode($inventoryFilter), $param);
+        return $this->get('metrics/dynamicgraphs/' . $urlencoded, $param);
     }
 
     private function collectData($tree){

--- a/lib/serverdensity/Api/Metrics.php
+++ b/lib/serverdensity/Api/Metrics.php
@@ -45,6 +45,27 @@ class Metrics extends AbstractApi
         return $this->get('metrics/graphs/'.urlencode($id), $param);
     }
 
+    /**
+    * Get dynamic metrics
+    * @link     https://apidocs.serverdensity.com/?python#get-metrics
+    * @param 	string		$inventoryFilter the filter to use to find inventory    
+    * @param    array       $filter an array of what you want to filter
+    * @param    timestamp   $start  the start of the period.
+    * @param    timestamp   $end    the end of the period
+    * @return   an array that is all available metrics.
+    */
+    public function dynamicMetrics($inventoryFilter, $filter, $start, $end){
+        $param = array(
+            'start' => gmdate("Y-m-d\TH:i:s\Z", $start),
+            'end' => gmdate("Y-m-d\TH:i:s\Z", $end),
+            'filter' => $filter
+        );
+
+        $param = $this->makeJsonReady($param);
+
+        return $this->get('metrics/dynamicgraphs/?inventoryFilter='.urlencode($inventoryFilter), $param);
+    }
+
     private function collectData($tree){
         foreach($tree as $tr){
             if (key_exists('data', $tr)) {

--- a/test/serverdensity/Tests/Api/MetricsTest.php
+++ b/test/serverdensity/Tests/Api/MetricsTest.php
@@ -31,6 +31,42 @@ class MetricsTest extends TestCase
         $result = $api->available('1', $start, $end);
     }
 
+    /**
+    * @test
+    */
+    public function shouldGetDynamicGraphs()
+    {
+        $expectedParam = array(
+            'start' => "2013-09-15T00:00:00Z",
+            'end' => "2013-09-15T17:10:00Z"
+        );
+
+        $start = mktime(0, 0, 0, 9, 15, 2013);
+        $end = mktime(17, 10, 0, 9, 15, 2013);
+
+        $filter = json_encode(array(
+            'networkTraffic' => array(
+                'eth0' => ['rxMByteS']
+            ))
+        );
+
+        $expectedParam = array(
+            'start' => "2013-09-15T00:00:00Z",
+            'end' => "2013-09-15T17:10:00Z",
+            'filter' => $filter
+        );
+
+        $searchPattern = 'test';
+
+        $api = $this->getApiMock('metrics');
+        $api->expects($this->once())
+            ->method('get')
+            ->with('metrics/dynamicgraphs/?inventoryFilter=' . 'test', $expectedParam);
+
+        $result = $api->dynamicMetrics($searchPattern, $filter, $start, $end);
+
+    }
+
 
     /**
     * @test

--- a/test/serverdensity/Tests/Api/MetricsTest.php
+++ b/test/serverdensity/Tests/Api/MetricsTest.php
@@ -61,9 +61,9 @@ class MetricsTest extends TestCase
         $api = $this->getApiMock('metrics');
         $api->expects($this->once())
             ->method('get')
-            ->with('metrics/dynamicgraphs/?inventoryFilter=test&ids=123&names=myname', $expectedParam);
+            ->with('metrics/dynamicgraphs/?inventoryFilter=test', $expectedParam);
 
-        $result = $api->dynamicMetrics($filter, $start, $end, $searchPattern, '123', 'myname');
+        $result = $api->dynamicMetrics($filter, $start, $end, $searchPattern);
 
     }
 

--- a/test/serverdensity/Tests/Api/MetricsTest.php
+++ b/test/serverdensity/Tests/Api/MetricsTest.php
@@ -61,9 +61,9 @@ class MetricsTest extends TestCase
         $api = $this->getApiMock('metrics');
         $api->expects($this->once())
             ->method('get')
-            ->with('metrics/dynamicgraphs/?inventoryFilter=' . 'test', $expectedParam);
+            ->with('metrics/dynamicgraphs/?inventoryFilter=test&ids=123&names=myname', $expectedParam);
 
-        $result = $api->dynamicMetrics($searchPattern, $filter, $start, $end);
+        $result = $api->dynamicMetrics($filter, $start, $end, $searchPattern, '123', 'myname');
 
     }
 


### PR DESCRIPTION
Added function to allow dynamic metrics to be returned from the API.

Is used in a similar way to ‘metrics’:

```$inventoryFilter = "SD-*";
$filter = array('networkTraffic' => [
'eth0' => ['rxMByteS']
]
);
$client->api('metrics')->dynamicMetrics($inventoryFilter, $filter,
time()-7200, time());   ```

Which will return eth0 rxMByteS metrics for all devices starting with
“SD-“

Needs tests @jonathan-s can you help with them?