### PR TITLE
Fix bad assignment in Alerts.php

### DIFF
--- a/lib/serverdensity/Api/Alerts.php
+++ b/lib/serverdensity/Api/Alerts.php
@@ -15,8 +15,8 @@ class Alerts extends AbstractApi
     */
     public function create($alert, $recipients, $wait, $repeat){
         $alert['recipients'] = json_encode($recipients);
-        $alert['wait'] = json_encode($recipients);
-        $alert['repeat'] = json_encode($recipients);
+        $alert['wait'] = json_encode($wait);
+        $alert['repeat'] = json_encode($repeat);
 
         return $this->post('alerts/configs/', $alert);
     }
@@ -53,10 +53,10 @@ class Alerts extends AbstractApi
             $fields['wait'] = json_encode($other['wait']);
         }
         if(array_key_exists('recipients', $other)){
-            $fields['recipients'] = json_encode($other['wait']);
+            $fields['recipients'] = json_encode($other['recipients']);
         }
         if(array_key_exists('repeat', $other)){
-            $fields['repeat'] = json_encode($other['wait']);
+            $fields['repeat'] = json_encode($other['repeat']);
         }
 
 

--- a/test/serverdensity/Tests/Api/AlertsTest.php
+++ b/test/serverdensity/Tests/Api/AlertsTest.php
@@ -35,8 +35,8 @@ class AlertsTest extends TestCase
         $expectedArray = array('_id' => '1', 'section' => 'system');
 
         $expectedArray['recipients'] = json_encode($recipients);
-        $expectedArray['wait'] = json_encode($recipients);
-        $expectedArray['repeat'] = json_encode($recipients);
+        $expectedArray['wait'] = json_encode($wait);
+        $expectedArray['repeat'] = json_encode($repeat);
 
 
 


### PR DESCRIPTION
Corrects the creation and update of alerts :smile: 

Previously, alerts were created but never triggered as wait and repeat values were set incorrectly to recipients :expressionless: 